### PR TITLE
unreferenced exception name fixed

### DIFF
--- a/ahtapot-gdys-gui/var/opt/gdysgui/fwsettings.py
+++ b/ahtapot-gdys-gui/var/opt/gdysgui/fwsettings.py
@@ -551,7 +551,7 @@ class Ui_FwSettingsWindow(QtGui.QWidget):
             child.close()
         except Exception as exc_err:
             child.close()
-            print ("Error authenticating. Reason: "%(exc_err))
+            print ("Error authenticating. Reason: "+str(exc_err))
             self.logger.send_log("error","error found while attempting to login to unlock\n"+str(exc_err))
             self.filelogger.send_log("error","error found while attempting to login to unlock\n"+str(exc_err))
             return False

--- a/ahtapot-gdys-gui/var/opt/gdysgui/fwsettings.py
+++ b/ahtapot-gdys-gui/var/opt/gdysgui/fwsettings.py
@@ -551,7 +551,7 @@ class Ui_FwSettingsWindow(QtGui.QWidget):
             child.close()
         except Exception as exc_err:
             child.close()
-            print ("Error authenticating. Reason: "%(err))
+            print ("Error authenticating. Reason: "%(exc_err))
             self.logger.send_log("error","error found while attempting to login to unlock\n"+str(exc_err))
             self.filelogger.send_log("error","error found while attempting to login to unlock\n"+str(exc_err))
             return False


### PR DESCRIPTION
During an exception when unlocking gdys-gui:

Traceback (most recent call last):
  File "/var/opt/gdysgui/fwsettings.py", line 514, in unlock_settings
    res = self.pam_login('root',root_pass)
  File "/var/opt/gdysgui/fwsettings.py", line 554, in pam_login
    print ("Error authenticating. Reason: "%(err))
NameError: global name 'err' is not defined